### PR TITLE
fix: empty response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/http-client/__mocks__/fetch.mock.ts
+++ b/src/http-client/__mocks__/fetch.mock.ts
@@ -27,6 +27,12 @@ export const mockFetchResponseWithError = (
     );
 };
 
+export const mockFetchResponseWithStatus = (status: number, statusText?: string) => {
+    return fetchMock.mockResponseOnce(
+        () => new Promise((resolve) => resolve({ init: { status, statusText } }))
+    );
+};
+
 export const mockFetchResponseWithTimeout = (value: object, timeout: number) => {
     return fetchMock.mockResponseOnce(
         () => new Promise((resolve) => setTimeout(() => resolve(JSON.stringify(value)), timeout))

--- a/src/http-client/__tests__/http-client-get.spec.ts
+++ b/src/http-client/__tests__/http-client-get.spec.ts
@@ -7,6 +7,7 @@ import {
     mockFetchResponseWithStatus,
 } from "../__mocks__/fetch.mock";
 import { CustomServerError } from "../../custom-errors/custom-server-error";
+import { EnumResponseFormat } from "../types";
 
 describe("Http Client Get Method", () => {
     fetchMock.enableMocks();
@@ -112,7 +113,10 @@ describe("Http Client Get Method", () => {
     it("should get value from response", async () => {
         mockFetchJSONResponse({ data: "test_result" });
 
-        const api = new FetchHTTPClient({ baseUrl: "http://test.com" });
+        const api = new FetchHTTPClient({
+            baseUrl: "http://test.com",
+            responseFormat: EnumResponseFormat.Json,
+        });
         const res = await api.get("test");
 
         expect(res).toEqual({ data: "test_result" });
@@ -158,14 +162,6 @@ describe("Http Client Get Method", () => {
         });
 
         await expect(api.get("test")).rejects.toEqual(new CustomServerError({ message: "test error" }));
-    });
-
-    it("should not parse json when status code is 204", async () => {
-        mockFetchResponseWithStatus(204, "No Content");
-
-        const api = new FetchHTTPClient({ baseUrl: "test.com" });
-
-        await expect(api.get("test")).resolves.toBeUndefined();
     });
 
     it("should return undefined when the response is empty", async () => {

--- a/src/http-client/__tests__/http-client-get.spec.ts
+++ b/src/http-client/__tests__/http-client-get.spec.ts
@@ -4,6 +4,7 @@ import {
     mockFetchJSONResponse,
     mockFetchResponseWithError,
     mockRejectResponse,
+    mockFetchResponseWithStatus,
 } from "../__mocks__/fetch.mock";
 import { CustomServerError } from "../../custom-errors/custom-server-error";
 
@@ -157,5 +158,21 @@ describe("Http Client Get Method", () => {
         });
 
         await expect(api.get("test")).rejects.toEqual(new CustomServerError({ message: "test error" }));
+    });
+
+    it("should not parse json when status code is 204", async () => {
+        mockFetchResponseWithStatus(204, "No Content");
+
+        const api = new FetchHTTPClient({ baseUrl: "test.com" });
+
+        await expect(api.get("test")).resolves.toBeUndefined();
+    });
+
+    it("should return undefined when the response is empty", async () => {
+        mockFetchResponseWithStatus(200, "");
+
+        const api = new FetchHTTPClient({ baseUrl: "test.com" });
+
+        await expect(api.get("test")).resolves.toBeUndefined();
     });
 });

--- a/src/http-client/__tests__/http-client-post.spec.ts
+++ b/src/http-client/__tests__/http-client-post.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../__mocks__/fetch.mock";
 import { CustomServerError } from "../../custom-errors/custom-server-error";
 import { contentTypeKey } from "../client-constants";
-import { EnumContentType } from "../types";
+import { EnumContentType, EnumResponseFormat } from "../types";
 
 describe("Http Client Post Method", () => {
     fetchMock.enableMocks();
@@ -25,6 +25,7 @@ describe("Http Client Post Method", () => {
         const api = new FetchHTTPClient({
             baseUrl: "http://test.com",
             headers,
+            responseFormat: EnumResponseFormat.Json,
         });
 
         const res = await api.post<{ data: number }, { data: string }>("go", {

--- a/src/http-client/__tests__/http-client-response.spec.ts
+++ b/src/http-client/__tests__/http-client-response.spec.ts
@@ -16,7 +16,10 @@ describe("Http Client Response Type", () => {
         const data = { data: "test" };
         mockFetchJSONResponse(data);
 
-        const api = new FetchHTTPClient({ baseUrl: "http://test.com" });
+        const api = new FetchHTTPClient({
+            baseUrl: "http://test.com",
+            responseFormat: EnumResponseFormat.Json,
+        });
         const res = await api.get("test");
 
         expect(res).toEqual(data);

--- a/src/http-client/fetch-http-client.ts
+++ b/src/http-client/fetch-http-client.ts
@@ -15,14 +15,14 @@ export class FetchHTTPClient implements IHTTPClient {
     private createErrorFn?: IHTTPClientOptions["createErrorFn"];
     private pendingRequests = new Map<string, Promise<Response>>();
     private preventRequestDuplication?: boolean;
-    private responseFormat: EnumResponseFormat;
+    private responseFormat: EnumResponseFormat | undefined;
 
     constructor(options: IHTTPClientOptions) {
         this.baseUrl = this.createBaseUrl(options);
         this.headers = options.headers;
         this.createErrorFn = options.createErrorFn;
         this.preventRequestDuplication = options.preventRequestDuplication;
-        this.responseFormat = options.responseFormat ?? EnumResponseFormat.Json;
+        this.responseFormat = options.responseFormat;
     }
 
     createAbortController() {
@@ -277,10 +277,8 @@ export class FetchHTTPClient implements IHTTPClient {
 
         const mergedFormat = format ?? this.responseFormat;
 
-        if (mergedFormat === EnumResponseFormat.Json) {
-            const text = await response.clone().text();
-            if (!text) return;
-        } else if (response.status === 204) return;
+        const text = await response.clone().text();
+        if (!text) return;
 
         switch (mergedFormat) {
             case EnumResponseFormat.Json:

--- a/src/http-client/fetch-http-client.ts
+++ b/src/http-client/fetch-http-client.ts
@@ -277,6 +277,11 @@ export class FetchHTTPClient implements IHTTPClient {
 
         const mergedFormat = format ?? this.responseFormat;
 
+        if (mergedFormat === EnumResponseFormat.Json) {
+            const text = await response.clone().text();
+            if (!text) return;
+        } else if (response.status === 204) return;
+
         switch (mergedFormat) {
             case EnumResponseFormat.Json:
                 return response.clone().json();

--- a/src/provider/__tests__/core-provider.spec.ts
+++ b/src/provider/__tests__/core-provider.spec.ts
@@ -16,7 +16,11 @@ describe("Data Provider", () => {
     const headers = {
         "content-type": EnumContentType.Json,
     };
-    const client = new FetchHTTPClient({ baseUrl: "http://test.com", headers });
+    const client = new FetchHTTPClient({
+        baseUrl: "http://test.com",
+        headers,
+        responseFormat: EnumResponseFormat.Json,
+    });
 
     fetchMock.enableMocks();
 
@@ -210,7 +214,7 @@ describe("Data Provider", () => {
 
         mockFetchResponseWithTimeout({ id: 1 }, 100);
         const firstResponse = await provider.get(
-            { url: "testRace" },
+            { url: "testRace", responseFormat: EnumResponseFormat.Json },
             { search: "te" },
             {
                 raceId: "1",
@@ -219,7 +223,7 @@ describe("Data Provider", () => {
 
         mockFetchResponseWithTimeout({ id: 2 }, 110);
         const secondResponse = await provider.get(
-            { url: "testRace" },
+            { url: "testRace", responseFormat: EnumResponseFormat.Json },
             { search: "test" },
             {
                 raceId: "1",
@@ -258,6 +262,7 @@ describe("Data Provider", () => {
         const config: ICachableRequestConfig<undefined, { id: number }[]> = {
             url: "getAll",
             cacheKey: "item",
+            responseFormat: EnumResponseFormat.Json,
         };
 
         const firstResponse = await provider.cachablePost(config);
@@ -297,6 +302,7 @@ describe("Data Provider", () => {
             validateResponse: (req?: number[]) => {
                 if (!req?.length) throw "error";
             },
+            responseFormat: EnumResponseFormat.Json,
         };
 
         await expect(() => provider.post(config)).rejects.toEqual(


### PR DESCRIPTION
## fix: empty response body

When the response is empty (e.g. 204 No Content) or invalid JSON, handleResponse function try to parse the response, which throws an error. This branch fixes this issue by checking the response parsing it.

- remove default type from responseFormat
- add empty response check to handleResponse 
- add unit test for empty response and fix existing tests