### PR TITLE
fix(dependency-resolve-error): far module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/global-module/global-module.ts
+++ b/src/global-module/global-module.ts
@@ -139,6 +139,7 @@ class GlobalModule {
         const { currentModule, ...dependencyOptions } = options ?? { type: "locale", path: [] };
 
         dependencyOptions.type = "locale";
+        dependencyOptions.dontThrowIfNotFound = true;
 
         for (const [name, module] of this.modules) {
             if (!currentModule || name !== currentModule) {

--- a/src/module/__tests__/module-dependency-resolve.spec.ts
+++ b/src/module/__tests__/module-dependency-resolve.spec.ts
@@ -296,6 +296,32 @@ describe("Module Dependency Resolve", () => {
         );
     });
 
+    it("should not throw error if dependency is from far module", () => {
+        const module = createModule();
+        const module2 = createModule("Module2");
+        const module3 = createModule("Module3");
+
+        class Test {}
+
+        class Test2 {
+            constructor(public test: Test) {}
+        }
+
+        class Test3 {
+            constructor(public test: Test2) {}
+        }
+
+        module.register(Test);
+        module2.register(Test2, { dependencies: [Test] });
+        module3.register(Test3, { dependencies: [Test2] });
+
+        const resolved = module3.resolve(Test3);
+
+        expect(resolved).toBeInstanceOf(Test3);
+        expect(resolved.test).toBeInstanceOf(Test2);
+        expect(resolved.test.test).toBeInstanceOf(Test);
+    });
+
     it("should throw error if cannot resolve because not registered", () => {
         const module = createModule();
         defaultLocalization.setLang("en-us");

--- a/src/module/core-module.ts
+++ b/src/module/core-module.ts
@@ -309,12 +309,17 @@ export class CoreModule implements ICoreModule {
             const instanceFromGlobal = this.resolveFromGlobal<T>(name, dependencyOptions);
             if (instanceFromGlobal) return instanceFromGlobal as T;
 
+            if (options.dontThrowIfNotFound) return undefined as T;
             this.throwNotRegisteredError(name, dependencyOptions.parentName);
         }
 
         this.checkAndPushPath(name, dependencyOptions);
 
-        let dependencies = this.resolveDependencies(constructorObj.dependencies ?? [], dependencyOptions);
+        let dependencies = this.resolveDependencies(constructorObj.dependencies ?? [], {
+            ...dependencyOptions,
+            type: "global",
+            dontThrowIfNotFound: false,
+        });
 
         if (dependenciesMapFn) dependencies = dependenciesMapFn(dependencies, constructorObj);
 

--- a/src/module/resolve-options.ts
+++ b/src/module/resolve-options.ts
@@ -2,6 +2,7 @@ import type { ResolveType } from "./resolve-type";
 
 export interface DependencyResolveOptions {
     type?: ResolveType;
+    dontThrowIfNotFound?: boolean;
     path?: string[];
     parentName?: string;
     dependencies?: Record<string, unknown> | unknown[];


### PR DESCRIPTION
If dependency is at the far module it was throwing error at the second module. 
Also deep dependencies were not looking global because of type = 'locale' was passing for dependency resolving.