### PR TITLE
Feat/custom error translate

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.3.16",
+    "version": "1.3.17",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/core/src/custom-errors/__tests__/custom-error.spec.ts
+++ b/packages/core/src/custom-errors/__tests__/custom-error.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { globalModule } from "../../global-module";
 import { defaultLocalization } from "../../localization";
 import { EnumAppLayer } from "../../shared";
@@ -6,8 +6,10 @@ import { CustomError } from "../index";
 import { EnumCustomErrorType } from "../statics/custom-error-type.enum";
 
 describe("Custom Error", () => {
-    it("should translate message", () => {
+    beforeEach(() => {
         globalModule.clear();
+    });
+    it("should translate message", () => {
         defaultLocalization.setLang("tr");
         defaultLocalization.setTranslations({ tr: { hi: "Merhaba" } });
         globalModule.setLocalization(defaultLocalization);
@@ -17,6 +19,21 @@ describe("Custom Error", () => {
             type: EnumCustomErrorType.Construction,
             message: "hi",
             translate: true,
+        });
+        const message = error.message;
+        expect(message).toEqual("Merhaba");
+    });
+
+    it("should translate as default if globalModule.isTranslateDefault is true", () => {
+        defaultLocalization.setLang("tr");
+        defaultLocalization.setTranslations({ tr: { hi: "Merhaba" } });
+        globalModule.setLocalization(defaultLocalization);
+        globalModule.useTranslateAsDefault();
+
+        const error = new CustomError({
+            layer: EnumAppLayer.Controller,
+            type: EnumCustomErrorType.Construction,
+            message: "hi",
         });
         const message = error.message;
         expect(message).toEqual("Merhaba");

--- a/packages/core/src/custom-errors/custom-error.ts
+++ b/packages/core/src/custom-errors/custom-error.ts
@@ -13,7 +13,9 @@ export class CustomError extends Error implements ICustomError {
     constructor(options: CustomErrorConstructorOptions) {
         let message = options.message;
 
-        if (options.translate)
+        const shouldTranslate = options.translate || globalModule.isTranslateDefault;
+
+        if (shouldTranslate)
             message =
                 globalModule.getLocalization()?.translate(options.message ?? "", options.translateArgs) ?? "";
 

--- a/packages/core/src/decorators/__tests__/injectable-decorators.spec.ts
+++ b/packages/core/src/decorators/__tests__/injectable-decorators.spec.ts
@@ -105,6 +105,60 @@ describe("Injectable Decorators", () => {
         expect(provider).toBeInstanceOf(TestProvider);
     });
 
+    it("should register provider with client as string", () => {
+        const module = createAndUseInject();
+        module.registerHttpClient(TestHttpClient, {});
+
+        class Test {
+        }
+
+        module.register(Test);
+
+        @injectable.provider({ key: "test_p", client: "TestHttpClient" })
+        class TestProvider implements IProvider {
+            test: Test;
+            client: IHTTPClient;
+
+            constructor(client: IHTTPClient, test: Test) {
+                this.test = test;
+                this.client = client;
+            }
+
+            async get() {
+                return null as any;
+            }
+
+            async post() {
+                return null as any;
+            }
+
+            async put() {
+                return null as any;
+            }
+
+            async delete() {
+                return null as any;
+            }
+
+            async patch() {
+                return null as any;
+            }
+
+            async request() {
+                return null as any;
+            }
+
+            async upload() {
+                return null as any;
+            }
+        }
+
+        const provider = module.resolveProvider<TestProvider>("test_p");
+        expect(provider).toBeInstanceOf(TestProvider);
+        expect(provider?.client).toBeInstanceOf(TestHttpClient);
+        expect(provider?.test).toBeInstanceOf(Test);
+    });
+
     it("should register provider with options and dependencies", () => {
         const module = createAndUseInject();
         module.registerHttpClient(TestHttpClient, {});

--- a/packages/core/src/global-module/__tests__/global-module.spec.ts
+++ b/packages/core/src/global-module/__tests__/global-module.spec.ts
@@ -132,6 +132,12 @@ describe("Global Module", () => {
         expect(isCalled).toBe(true);
     });
 
+    it("should turn on translate at custom error", () => {
+        globalModule.useTranslateAsDefault();
+
+        expect(globalModule.isTranslateDefault).toBe(true);
+    });
+
     it("should clear", () => {
         globalModule.setLocalization(mockLocalization);
         globalModule.setCloneUtil(mockCloneUtil);
@@ -140,6 +146,7 @@ describe("Global Module", () => {
         globalModule.setDateUtil(mockDateUtil);
         globalModule.setObserver(MockObserver);
         globalModule.addToSharedHeaders({ test: "1" });
+        globalModule.useTranslateAsDefault();
 
         const key = "Module1";
         const module = createModule(key);
@@ -155,6 +162,7 @@ describe("Global Module", () => {
         const dateUtil = globalModule.getDateUtil();
         const observer = globalModule.createObserver<string>();
         const headers = globalModule.getSharedHeaders();
+        const isTranslateDefault = globalModule.isTranslateDefault;
 
         expect(localization).toBe(null);
         expect(clone).toBe(null);
@@ -164,5 +172,6 @@ describe("Global Module", () => {
         expect(resolvedModule).toBe(undefined);
         expect(observer).toBe(undefined);
         expect(headers).toEqual({});
+        expect(isTranslateDefault).toBe(false);
     });
 });

--- a/packages/core/src/global-module/global-module.ts
+++ b/packages/core/src/global-module/global-module.ts
@@ -20,6 +20,7 @@ class GlobalModule {
     private observer: (new () => IObserver<any>) | null = null;
     private sharedHeaders: Record<string, string> = {};
     private customErrorListener: ((error: Error) => void) | null = null;
+    private _isTranslateDefault = false;
 
     private createNotRegisteredErrorMessage(type: string) {
         const message = `${type} is not registered`;
@@ -27,6 +28,14 @@ class GlobalModule {
             type: EnumCustomErrorType.Construction,
             message,
         });
+    }
+
+    get isTranslateDefault() {
+        return this._isTranslateDefault;
+    }
+
+    useTranslateAsDefault() {
+        this._isTranslateDefault = true;
     }
 
     setCustomErrorListener(method: (error: Error) => void) {
@@ -166,6 +175,7 @@ class GlobalModule {
         this.dateUtil = null;
         this.observer = null;
         this.sharedHeaders = {};
+        this._isTranslateDefault = false;
         this.modules.clear();
     }
 }

--- a/packages/core/src/module/core-module.interface.ts
+++ b/packages/core/src/module/core-module.interface.ts
@@ -21,7 +21,7 @@ export type RegisterClassOptions = {
 
 export type RegisterProviderOptions = {
     key?: string;
-    client?: IHTTPClientConstuctor;
+    client?: IHTTPClientConstuctor | string;
 } & RegisterClassOptions;
 
 export type RegisterControllerOptions = {


### PR DESCRIPTION
- give client as string for providers 
- add translations as default for custom error method on globalModule