### PR TITLE
Feat: CL-636: http-client template

### DIFF
--- a/packages/swagger-codegen/package.json
+++ b/packages/swagger-codegen/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/swagger-codegen",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "type": "module",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",

--- a/packages/swagger-codegen/src/templates/http-client.ejs
+++ b/packages/swagger-codegen/src/templates/http-client.ejs
@@ -2,19 +2,18 @@
 const { apiConfig } = it;
 %>
 
-import { FetchHTTPClient, IHTTPClientOptions } from "@pusula/module.core";
+import { FetchHTTPClient, type IHTTPClientOptions } from "@pusula/module.core";
 import { createError } from "../utils"
 
-export const createHttpClient = (options: Pick<IHTTPClientOptions, "protocol"|"baseUrl">) => {
-    const coreHttpClient = new FetchHTTPClient({
+export const createHttpClient = (options: Pick<IHTTPClientOptions, "protocol"|"baseUrl"|"queryStringFormat">) => {
+    return new FetchHTTPClient({
         protocol: options.protocol,
         baseUrl: options.baseUrl,
+        queryStringFormat: options.queryStringFormat,
         preventRequestDuplication: true,
         headers: {
             'content-type': 'application/json',
         },
         createErrorFn: createError,
     });
-
-    return coreHttpClient;
 }


### PR DESCRIPTION
# Feat: CL-636: http-client template

- queryStringFormat added to http-client template
- IHTTPClientOptions imported as type
- Redundant local variable removed
- package version updated

### Task ID:
- [CL-636](https://pusulayazilimprojects.atlassian.net/browse/CL-636)