### PR TITLE
Fix/mixed provider argument types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.4.9",
+    "version": "1.4.10",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.4.11",
+    "version": "1.4.12",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/module.core",
-    "version": "1.4.10",
+    "version": "1.4.11",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/core/src/http-client/__tests__/http-client-post.spec.ts
+++ b/packages/core/src/http-client/__tests__/http-client-post.spec.ts
@@ -151,4 +151,64 @@ describe("Http Client Post Method", () => {
             method: "POST",
         });
     });
+
+    it("should separete query, body and route with dataMap options", async () => {
+        mockFetchJSONResponse({});
+
+        const headers = {
+            "content-type": EnumContentType.Json,
+        };
+
+        const api = new FetchHTTPClient({
+            baseUrl: "http://test.com",
+            headers,
+        });
+
+        const request = { route: { id: 1 }, body: ["ali", "veli"], query: { name: "salih" } };
+
+        await api.post("test/${id}", request, {
+            queryKeys: ["name"],
+            dataMaps: {
+                body: "body",
+                query: "query",
+                route: "route",
+            },
+        });
+
+        expect(fetch).toBeCalledWith("http://test.com/test/1?name=salih", {
+            method: "POST",
+            body: JSON.stringify(request.body),
+            headers,
+        });
+    });
+
+    it("should separete query, body and route with method type dataMaps", async () => {
+        mockFetchJSONResponse({});
+
+        const headers = {
+            "content-type": EnumContentType.Json,
+        };
+
+        const api = new FetchHTTPClient({
+            baseUrl: "http://test.com",
+            headers,
+        });
+
+        const request = { test: { id: 1 }, test2: ["ali", "veli"], test3: { name: "salih" } };
+
+        await api.post("test/${id}", request, {
+            queryKeys: ["name"],
+            dataMaps: {
+                body: (e) => e.test2,
+                query: (e) => e.test3,
+                route: (e) => e.test,
+            },
+        });
+
+        expect(fetch).toBeCalledWith("http://test.com/test/1?name=salih", {
+            method: "POST",
+            body: JSON.stringify(request.test2),
+            headers,
+        });
+    });
 });

--- a/packages/core/src/http-client/__tests__/http-client-post.spec.ts
+++ b/packages/core/src/http-client/__tests__/http-client-post.spec.ts
@@ -171,7 +171,7 @@ describe("Http Client Post Method", () => {
             dataMaps: {
                 body: "body",
                 query: "query",
-                route: "route",
+                path: "route",
             },
         });
 
@@ -201,7 +201,7 @@ describe("Http Client Post Method", () => {
             dataMaps: {
                 body: (e) => e.test2,
                 query: (e) => e.test3,
-                route: (e) => e.test,
+                path: (e) => e.test,
             },
         });
 

--- a/packages/core/src/http-client/fetch-http-client.ts
+++ b/packages/core/src/http-client/fetch-http-client.ts
@@ -331,10 +331,10 @@ export class FetchHTTPClient implements IHTTPClient {
     }
 
     private createDataMap<TRequest>(data?: TRequest, options?: RequestOptions<TRequest>) {
-        const dataMap: { query: unknown; body: unknown; route: unknown } = {
+        const dataMap: { query: unknown; body: unknown; path: unknown } = {
             query: data,
             body: data,
-            route: data,
+            path: data,
         };
 
         if (data && options?.dataMaps) {
@@ -346,8 +346,8 @@ export class FetchHTTPClient implements IHTTPClient {
                 dataMap.query = this.getValueWithDataMap(data, options.dataMaps.query);
             }
 
-            if (options.dataMaps.route) {
-                dataMap.route = this.getValueWithDataMap(data, options.dataMaps.route);
+            if (options.dataMaps.path) {
+                dataMap.path = this.getValueWithDataMap(data, options.dataMaps.path);
             }
         }
         return dataMap;
@@ -365,8 +365,8 @@ export class FetchHTTPClient implements IHTTPClient {
 
         const dataMap = this.createDataMap(data, options);
 
-        if (ensureObject(dataMap.route)) {
-            customUrl = this.mergeUrlRouteParams(url, dataMap.route as Record<string, unknown>);
+        if (ensureObject(dataMap.path)) {
+            customUrl = this.mergeUrlRouteParams(url, dataMap.path as Record<string, unknown>);
         }
 
         if (dataMap.query !== undefined && (method === EnumRequestMethod.GET || options?.queryKeys?.length)) {

--- a/packages/core/src/http-client/types/http-client.interface.ts
+++ b/packages/core/src/http-client/types/http-client.interface.ts
@@ -14,7 +14,7 @@ export type IHTTPClient = {
         url: string,
         method: EnumRequestMethod,
         data?: TRequest,
-        options?: RequestOptions
+        options?: RequestOptions<TRequest>
     ) => Promise<TResponse | undefined>;
 
     get: ClientRequest;

--- a/packages/core/src/http-client/types/request-options.interface.ts
+++ b/packages/core/src/http-client/types/request-options.interface.ts
@@ -1,9 +1,18 @@
 import type { IAbortController } from "./abort-controller.interface";
 import type { EnumResponseFormat } from "./response-format.enum";
 
-export type RequestOptions = {
+export type RequestDataMapValue<TRequest> = string | keyof TRequest | ((data: TRequest) => unknown);
+
+export interface RequestDataMap<TRequest> {
+    body: RequestDataMapValue<TRequest>;
+    route?: RequestDataMapValue<TRequest>;
+    query?: RequestDataMapValue<TRequest>;
+}
+
+export interface RequestOptions<TRequest = unknown> {
     abortController?: IAbortController;
     headers?: Record<string, string>;
     responseFormat?: EnumResponseFormat;
     queryKeys?: string[];
-};
+    dataMaps?: RequestDataMap<TRequest>;
+}

--- a/packages/core/src/http-client/types/request-options.interface.ts
+++ b/packages/core/src/http-client/types/request-options.interface.ts
@@ -5,7 +5,7 @@ export type RequestDataMapValue<TRequest> = string | keyof TRequest | ((data: TR
 
 export interface RequestDataMap<TRequest> {
     body: RequestDataMapValue<TRequest>;
-    route?: RequestDataMapValue<TRequest>;
+    path?: RequestDataMapValue<TRequest>;
     query?: RequestDataMapValue<TRequest>;
 }
 

--- a/packages/core/src/provider/__tests__/core-provider.spec.ts
+++ b/packages/core/src/provider/__tests__/core-provider.spec.ts
@@ -370,6 +370,30 @@ describe("Data Provider", () => {
         );
     });
 
+    it("shouldn't throw error for validation if values exists in any dataMaps part ", async () => {
+        globalModule.setLocalization(mockLocalization);
+
+        const provider = new CoreProvider(client);
+
+        type TestRequest = { body: { name: string }; params: { id: string } };
+        const config: IRequestConfig<TestRequest, number> = {
+            url: "test",
+            validationProperties: [
+                {
+                    name: "id",
+                    type: "string",
+                    rules: { isRequired: true },
+                },
+            ],
+            dataMaps: {
+                body: "body",
+                path: "params",
+            },
+        };
+
+        expect(() => provider.post(config, { body: { name: "salih" }, params: { id: "test" } })).not.rejects;
+    });
+
     it("should validate request with validation properties", async () => {
         globalModule.setLocalization(mockLocalization);
 

--- a/packages/core/src/provider/__tests__/core-provider.spec.ts
+++ b/packages/core/src/provider/__tests__/core-provider.spec.ts
@@ -334,7 +334,43 @@ describe("Data Provider", () => {
         );
     });
 
-    it("should validate request with validation function", async () => {
+    it("should validate request with dataMaps ", async () => {
+        globalModule.setLocalization(mockLocalization);
+
+        const provider = new CoreProvider(client);
+
+        type TestRequest = { body: { name: string }; params: { id: string } };
+        const config: IRequestConfig<TestRequest, number> = {
+            url: "test",
+            validationProperties: [
+                {
+                    name: "name",
+                    type: "string",
+                    rules: { isRequired: true },
+                },
+                {
+                    name: "id",
+                    type: "string",
+                    rules: { isRequired: true },
+                },
+            ],
+            dataMaps: {
+                body: "body",
+                path: "params",
+            },
+        };
+
+        await expect(() =>
+            provider.post(config, { body: { name: "salih" }, params: { id: "" } })
+        ).rejects.toEqual(
+            new CustomProviderError({
+                type: EnumCustomErrorType.RequestValidation,
+                message: "id: required",
+            })
+        );
+    });
+
+    it("should validate request with validation properties", async () => {
         globalModule.setLocalization(mockLocalization);
 
         const provider = new CoreProvider(client);

--- a/packages/core/src/provider/__tests__/validate.spec.ts
+++ b/packages/core/src/provider/__tests__/validate.spec.ts
@@ -163,6 +163,19 @@ describe("validate", () => {
             },
             [],
         ],
+        [
+            {
+                value: { identity: "12121212122" },
+                properties: [
+                    {
+                        name: "identity",
+                        type: "string",
+                        rules: { isRequired: true, pattern: "^[1-9]{1}[0-9]{9}[02468]{1}$" },
+                    },
+                ],
+            },
+            [],
+        ],
     ];
 
     test.each(cases)(`validate options: %o, expected : %o`, (options, expected) => {

--- a/packages/core/src/provider/core-provider.ts
+++ b/packages/core/src/provider/core-provider.ts
@@ -4,6 +4,7 @@ import type { ICachableRequestConfig, IRequestConfig, ProviderRequestOptions } f
 import type { ICache } from "../cache";
 import { CustomProviderError, EnumCustomErrorType } from "../custom-errors";
 import { validateAndThrow } from "./validator";
+import { createDataMap } from "src/shared/create-data-map";
 
 export class CoreProvider implements IProvider {
     protected baseUrl: string | null = null;
@@ -198,6 +199,19 @@ export class CoreProvider implements IProvider {
     private async validateRequest<TRequest = undefined, TResponse = undefined>(
         config: IRequestConfig<TRequest, TResponse>,
         data: TRequest | undefined
+    ) {
+        if (!config.dataMaps) return this.validateData(config, data);
+
+        const dataMap = createDataMap(data, config);
+
+        await this.validateData(config, dataMap.body as TRequest);
+        await this.validateData(config, dataMap.path as TRequest);
+        await this.validateData(config, dataMap.query as TRequest);
+    }
+
+    private async validateData<TRequest = undefined, TResponse = undefined>(
+        config: IRequestConfig<TRequest, TResponse>,
+        data?: TRequest
     ) {
         try {
             if (config.validateRequest) {

--- a/packages/core/src/provider/core-provider.ts
+++ b/packages/core/src/provider/core-provider.ts
@@ -153,10 +153,11 @@ export class CoreProvider implements IProvider {
     private createRequestOptions<TRequest, TResponse>(
         config: IRequestConfig<TRequest, TResponse>,
         options?: ProviderRequestOptions
-    ): RequestOptions {
-        const requestOptions: RequestOptions = {
+    ): RequestOptions<TRequest> {
+        const requestOptions: RequestOptions<TRequest> = {
             responseFormat: options?.responseFormat ?? config.responseFormat,
             queryKeys: config.queryKeys as string[],
+            dataMaps: config.dataMaps,
         };
 
         const headers = { ...(options?.headers ?? {}), ...(config.headers ?? {}) };

--- a/packages/core/src/provider/types/request-config.interface.ts
+++ b/packages/core/src/provider/types/request-config.interface.ts
@@ -1,3 +1,4 @@
+import type { RequestDataMap } from "src/http-client/types/request-options.interface";
 import type { EnumResponseFormat } from "../../http-client";
 import type { ProviderRequestOptions } from "./provider-request-options.interface";
 
@@ -21,11 +22,12 @@ export type IRequestConfig<TRequest = undefined, TResponse = undefined> = {
     /**
      * adds query parameters to url with this keys if value exists
      */
-    queryKeys?: (keyof TRequest)[];
+    queryKeys?: string[];
+    dataMaps?: RequestDataMap<TRequest>;
 };
 
 export type ValidationProperty<T> = {
-    name: keyof T;
+    name: keyof T | string;
     type: string;
     rules: {
         isRequired?: boolean;

--- a/packages/core/src/provider/validator.ts
+++ b/packages/core/src/provider/validator.ts
@@ -5,7 +5,7 @@ export const validate = <T>({ value, properties }: { value?: T; properties: Vali
     const validationResults: ValidationResult[] = [];
 
     properties.forEach((property) => {
-        const propValue = value?.[property.name];
+        const propValue = value?.[property.name as keyof T];
 
         const res = validateProp(property, propValue);
         if (res.length)

--- a/packages/core/src/shared/create-data-map.ts
+++ b/packages/core/src/shared/create-data-map.ts
@@ -1,0 +1,33 @@
+import type { RequestOptions } from "src/http-client";
+import type { RequestDataMapValue } from "src/http-client/types/request-options.interface";
+
+const getValueWithDataMap = <TRequest>(data: TRequest, mapper: RequestDataMapValue<TRequest>) => {
+    if (typeof mapper === "function") return mapper(data);
+    else return data[mapper as keyof TRequest];
+};
+
+export const createDataMap = <TRequest>(
+    data?: TRequest,
+    options?: Pick<RequestOptions<TRequest>, "dataMaps">
+) => {
+    const dataMap: { query: unknown; body: unknown; path: unknown } = {
+        query: data,
+        body: data,
+        path: data,
+    };
+
+    if (data && options?.dataMaps) {
+        if (options.dataMaps.body) {
+            dataMap.body = getValueWithDataMap(data, options.dataMaps.body);
+        }
+
+        if (options.dataMaps.query) {
+            dataMap.query = getValueWithDataMap(data, options.dataMaps.query);
+        }
+
+        if (options.dataMaps.path) {
+            dataMap.path = getValueWithDataMap(data, options.dataMaps.path);
+        }
+    }
+    return dataMap;
+};

--- a/packages/swagger-codegen/package.json
+++ b/packages/swagger-codegen/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/swagger-codegen",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "type": "module",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",

--- a/packages/swagger-codegen/package.json
+++ b/packages/swagger-codegen/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/swagger-codegen",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "type": "module",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",

--- a/packages/swagger-codegen/package.json
+++ b/packages/swagger-codegen/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pusula/swagger-codegen",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "type": "module",
     "main": "./dist/index.umd.cjs",
     "module": "./dist/index.js",

--- a/packages/swagger-codegen/src/templates/procedure-call.ejs
+++ b/packages/swagger-codegen/src/templates/procedure-call.ejs
@@ -5,24 +5,7 @@ const { pathParams, path, method, payload, security, requestParams } = route.req
 const { type } = route.response;
 const routeDocs = includeFile("./route-docs", { config, route, utils });
 
-const requestTypes = [];
 
-if (payload)
-{
-    requestTypes.push(payload.type)
-}
-
-if (requestParams)
-{
-    requestTypes.push(getInlineParseContent(requestParams))
-}
-
-if (pathParams)
-{
-    requestTypes.push(pathParams.type);
-}
-
-let requestType = requestTypes.join(' & ') || 'undefined';
 
 const responseType = route.response.type;
 const name = route.routeName.usage.replace('app','')
@@ -32,11 +15,13 @@ const cachableName = `cachable${capitalize(name)}`;
 const methodName = name.replace(name[0],name[0].toLowerCase())
 
 const configGetterName = `${methodName}Config`
+const configName = `${route.routeName.usage}Config`
 
+let requestType = `typeof ${configName} extends ICachableRequestConfig<infer X> ? X : never`;
 %>
 
 get <%~ configGetterName %>(){
-return Object.freeze(<%~route.routeName.usage %>Config);
+return Object.freeze(<%~ configName %>);
 }
 
 /**
@@ -47,7 +32,7 @@ return Object.freeze(<%~route.routeName.usage %>Config);
 */
 <%~ methodName %> = (request:<%~ requestType %>,options?: ProviderRequestOptions) =>
 {
-return this.<%~method%>(<%~route.routeName.usage %>Config,request,options)
+return this.<%~method%>(<%~ configName %>,request,options)
 }
 
 <% if(method === "get") {
@@ -62,6 +47,6 @@ return this.<%~method%>(<%~route.routeName.usage %>Config,request,options)
 */
 <%~ cachableName %> = (request:<%~ requestType %>,options?: ProviderRequestOptions) =>
 {
-return this.<%~cachableMethod%>(<%~route.routeName.usage %>Config,request,options)
+return this.<%~cachableMethod%>(<%~ configName %>,request,options)
 }
 <% }%>

--- a/packages/swagger-codegen/src/templates/request-config.ejs
+++ b/packages/swagger-codegen/src/templates/request-config.ejs
@@ -109,9 +109,6 @@ if(hasArrayType){
     const query = requestTypeMap.query ? `${dataMaps.query}: ${requestTypeMap.query},` : '';
 
     requestType = `{${body}${path}${query}}`;
-
-    console.log('requestType',requestType)
-
 }
 
 const responseType = route.response.type;

--- a/packages/swagger-codegen/src/templates/request-config.ejs
+++ b/packages/swagger-codegen/src/templates/request-config.ejs
@@ -5,26 +5,59 @@ const {_, getInlineParseContent, getParseContent, parseSchema, getComponentByRef
 const { path, method, payload, query, formData, security, requestParams, pathParams } = route.request;
 
 const securityTmpl = security ? 'true' : null;
+const requestTypeMap = {
+    body:null,
+    query:null,
+    path:null
+}
+let hasArrayType = false;
+
 const requestTypes = [];
-const queryKeys = []
+const queryKeys = [];
+
+const findContract = (name) => {
+    return modelTypes.find(e=> e.name === name)
+}
 
 if (payload)
 {
+    requestTypeMap.body = payload.type;
     requestTypes.push(payload.type)
+
+    if(payload.type.includes('[]'))
+    {
+        hasArrayType = true
+    }
 }
 
 if (requestParams)
 {
-    requestTypes.push(getInlineParseContent(requestParams))
-    const requestParamContract = modelTypes.find(e=> e.name === getInlineParseContent(requestParams));
+    const name = getInlineParseContent(requestParams)
+
+    requestTypeMap.query = name;
+    requestTypes.push(name);
+
+    const requestParamContract = findContract(name);
+
     Object.values(requestParamContract.properties).forEach(item => {
         if(item.in === "query") queryKeys.push(item.name);
     })
+
+    if(name.includes('[]'))
+    {
+        hasArrayType = true
+    }
 }
 
 if (pathParams)
 {
+    requestTypeMap.path = pathParams.type;
     requestTypes.push(pathParams.type);
+
+    if(pathParams.type.includes('[]'))
+    {
+        hasArrayType = true
+    }
 }
 
 let validationProperties = [];
@@ -61,6 +94,25 @@ contracts.forEach(contract => {
    
 
 let requestType = requestTypes.join(' & ') || 'undefined';
+let dataMaps;
+
+if(hasArrayType){
+    dataMaps = {
+        body:'body',
+        path:'path',
+        query:'query'
+    }
+
+
+    const body = requestTypeMap.body ? `${dataMaps.body}: ${requestTypeMap.body},` : '';
+    const path = requestTypeMap.path ? `${dataMaps.path}: ${requestTypeMap.path},` : '';
+    const query = requestTypeMap.query ? `${dataMaps.query}: ${requestTypeMap.query},` : '';
+
+    requestType = `{${body}${path}${query}}`;
+
+    console.log('requestType',requestType)
+
+}
 
 const responseType = route.response.type;
 
@@ -91,4 +143,5 @@ const <% ~requestName %>Config: ICachableRequestConfig<<% ~requestType %>, <% ~r
   <%~ responseFormatTmpl ? `responseFormat: ${responseFormatTmpl},` : '' %>
   <%~ validationProperties ? `validationProperties: ${JSON.stringify(validationProperties)},` : ''  %>
   <%~ queryKeys.length ? `queryKeys: ${JSON.stringify(queryKeys)},`: '' %>
+  <%~ dataMaps ? `dataMaps: ${JSON.stringify(dataMaps)},`: '' %>
   };

--- a/packages/swagger-codegen/src/templates/request-config.ejs
+++ b/packages/swagger-codegen/src/templates/request-config.ejs
@@ -104,9 +104,9 @@ if(hasArrayType){
     }
 
 
-    const body = requestTypeMap.body ? `${dataMaps.body}: ${requestTypeMap.body},` : '';
-    const path = requestTypeMap.path ? `${dataMaps.path}: ${requestTypeMap.path},` : '';
-    const query = requestTypeMap.query ? `${dataMaps.query}: ${requestTypeMap.query},` : '';
+    const body = requestTypeMap.body ? `${dataMaps.body}?: ${requestTypeMap.body},` : '';
+    const path = requestTypeMap.path ? `${dataMaps.path}?: ${requestTypeMap.path},` : '';
+    const query = requestTypeMap.query ? `${dataMaps.query}?: ${requestTypeMap.query},` : '';
 
     requestType = `{${body}${path}${query}}`;
 }


### PR DESCRIPTION
On mixed types for body, path and query with Arrays creating the request type for provider creates problems. 
To solve it i have added dataMaps to provider config options and refactored swagger-codegen to generate codes to fit that